### PR TITLE
Allow for installation of components from Git

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ This Ansible role has the following features for [Prometheus](http://prometheus.
 ### Versioning note
 For all 3 of the possible `prometheus_components` you can set the respective version to `git` to download the latest code and compile from the Prometheus repositories.
 There are no external requirements needed to compile from source, as Prometheus provides them all via the install scripts.
+Git, Mercurial, GZip and Curl will be installed from your package manager (yum or apt). If you already have all dependencies, nothing will be installed.
 
 For example, you can set all three variables to `git` to get the latest code for each component.
 

--- a/README.md
+++ b/README.md
@@ -21,6 +21,18 @@ This Ansible role has the following features for [Prometheus](http://prometheus.
 
 ## Role Variables
 
+### Versioning note
+For all 3 of the possible `prometheus_components` you can set the respective version to `git` to download the latest code and compile from the Prometheus repositories.
+There are no external requirements needed to compile from source, as Prometheus provides them all via the install scripts.
+
+For example, you can set all three variables to `git` to get the latest code for each component.
+
+```yaml
+prometheus_version: git
+prometheus_node_exporter_version: git
+prometheus_alertmanager_version: git
+```
+
 ### Mandatory variables
 
 None.

--- a/tasks/install-alertmanager.yml
+++ b/tasks/install-alertmanager.yml
@@ -25,13 +25,13 @@
   when: prometheus_alertmanager_version == "git"
 
 - name: delete the alertmanager directory if it already exists
-  file: path="{{ prometheus_download_path }}/alertmanager" state=absent
+  file: path="{{ prometheus_download_path }}/alertmanager-master" state=absent
   when: prometheus_alertmanager_version == "git"
 
 - name: download alertmanager tarball
   get_url: url="{{ prometheus_alertmanager_tarball_url }}" dest="{{ prometheus_download_path }}/alertmanager.tar.gz" force=yes
 
-- name: uutar alertmanager tarball
+- name: untar alertmanager tarball
   unarchive:
     src: "{{ prometheus_download_path }}/alertmanager.tar.gz"
     dest: "{{ prometheus_untar_path }}"
@@ -40,12 +40,12 @@
 - name: build alertmanager
   command: make
   args:
-    chdir: "{{ prometheus_download_path }}/alertmanager"
+    chdir: "{{ prometheus_download_path }}/alertmanager-master"
     creates: alertmanager
   when: prometheus_alertmanager_version == "git"
 
 - name: move the built alertmanager to the install path
-  command: "mv {{ prometheus_download_path }}/alertmanager {{ prometheus_install_path }}"
+  command: "mv {{ prometheus_download_path }}/alertmanager-master/alertmanager {{ prometheus_install_path }}"
   when: prometheus_alertmanager_version == "git"
 
 - name: set permissions, owner and group

--- a/tasks/install-alertmanager.yml
+++ b/tasks/install-alertmanager.yml
@@ -66,7 +66,7 @@
   template: src="../templates/alertmanager.sysvinit.{{ ansible_os_family|lower }}.sh.j2"  dest="/etc/init.d/alertmanager"  mode="a+x"
 
 - name: set INIT status
-  service: name=alertmanager enabled=yes state=started
+  service: name=alertmanager enabled=yes state=restarted
 
 - name: copy alertmanager main config file from playbook's, if any
   template: src="{{ playbook_dir }}/{{ prometheus_alertmanager_conf }}"  dest="{{ prometheus_config_path }}/alertmanager.conf"

--- a/tasks/install-alertmanager.yml
+++ b/tasks/install-alertmanager.yml
@@ -6,43 +6,58 @@
 # @see http://prometheus.io/docs/introduction/getting_started/
 #
 
-
 - name: set internal variables for convenience
   set_fact:
     prometheus_alertmanager_tarball_url: "https://github.com/prometheus/alertmanager/releases/download/{{ prometheus_alertmanager_version }}/alertmanager-{{ prometheus_alertmanager_version }}.linux-amd64.tar.gz"
-  when: ansible_userspace_bits == "64"
+    prometheus_untar_path: "{{ prometheus_install_path }}"
+  when: prometheus_alertmanager_version != "git" and ansible_userspace_bits == "64"
 
 - name: set internal variables for convenience
   set_fact:
     prometheus_alertmanager_tarball_url: "https://github.com/prometheus/alertmanager/releases/download/{{ prometheus_alertmanager_version }}/alertmanager-{{ prometheus_alertmanager_version }}.linux-386.tar.gz"
-  when: ansible_userspace_bits == "32"
+    prometheus_untar_path: "{{ prometheus_install_path }}"
+  when: prometheus_alertmanager_version != "git" and ansible_userspace_bits == "32"
 
+- name: set internal variables for convenience
+  set_fact:
+    prometheus_alertmanager_tarball_url: "https://github.com/prometheus/alertmanager/archive/master.tar.gz"
+    prometheus_untar_path: /tmp
+  when: prometheus_alertmanager_version == "git"
 
-
-- name: mkdir for data
-  file:
-    path: "{{ item }}"
-    state: directory
-    owner: "{{ prometheus_user }}"
-    group: "{{ prometheus_group }}"
-    mode: "u=rwx,g=rx,o="
-  with_items:
-    - "{{ prometheus_db_path }}"
-
+- name: delete the alertmanager directory if it already exists
+  file: path="{{ prometheus_download_path }}/alertmanager" state=absent
+  when: prometheus_alertmanager_version == "git"
 
 - name: download alertmanager tarball
-  get_url: url="{{ prometheus_alertmanager_tarball_url }}"  dest="{{ prometheus_download_path }}/alertmanager.tar.gz"
+  get_url: url="{{ prometheus_alertmanager_tarball_url }}" dest="{{ prometheus_download_path }}/alertmanager.tar.gz" force=yes
 
 - name: uutar alertmanager tarball
   unarchive:
     src: "{{ prometheus_download_path }}/alertmanager.tar.gz"
-    dest: "{{ prometheus_install_path }}"
-    owner: "{{ prometheus_user }}"
-    group: "{{ prometheus_group }}"
-    mode: "go-w"
+    dest: "{{ prometheus_untar_path }}"
     copy: no
 
+- name: build alertmanager
+  command: make
+  args:
+    chdir: "{{ prometheus_download_path }}/alertmanager"
+    creates: alertmanager
+  when: prometheus_alertmanager_version == "git"
 
+- name: move the built alertmanager to the install path
+  command: "mv {{ prometheus_download_path }}/alertmanager {{ prometheus_install_path }}"
+  when: prometheus_alertmanager_version == "git"
+
+- name: set permissions, owner and group
+  file: path={{ prometheus_install_path }}/alertmanager owner={{ prometheus_user }} group={{ prometheus_group }} mode="go-w"
+
+- name: mkdir for data
+  file:
+    path: "{{ prometheus_db_path }}"
+    state: directory
+    owner: "{{ prometheus_user }}"
+    group: "{{ prometheus_group }}"
+    mode: "u=rwx,g=rx,o="
 
 - name: set alertmanager variables
   copy: src="../files/etc-default-alertmanager"  dest=/etc/default/alertmanager
@@ -52,8 +67,6 @@
 
 - name: set INIT status
   service: name=alertmanager enabled=yes state=started
-
-
 
 - name: copy alertmanager main config file from playbook's, if any
   template: src="{{ playbook_dir }}/{{ prometheus_alertmanager_conf }}"  dest="{{ prometheus_config_path }}/alertmanager.conf"

--- a/tasks/install-node-exporter.yml
+++ b/tasks/install-node-exporter.yml
@@ -6,32 +6,58 @@
 # @see http://prometheus.io/docs/introduction/getting_started/
 #
 
-
 - name: set internal variables for convenience
   set_fact:
     prometheus_node_exporter_tarball_url: "https://github.com/prometheus/node_exporter/releases/download/{{ prometheus_node_exporter_version }}/node_exporter-{{ prometheus_node_exporter_version }}.linux-amd64.tar.gz"
-  when: ansible_userspace_bits == "64"
+    prometheus_untar_path: "{{ prometheus_install_path }}"
+  when: prometheus_node_exporter_version != "git" and ansible_userspace_bits == "64"
 
 - name: set internal variables for convenience
   set_fact:
     prometheus_node_exporter_tarball_url: "https://github.com/prometheus/node_exporter/releases/download/{{ prometheus_node_exporter_version }}/node_exporter-{{ prometheus_node_exporter_version }}.linux-386.tar.gz"
-  when: ansible_userspace_bits == "32"
+    prometheus_untar_path: "{{ prometheus_install_path }}"
+  when: prometheus_node_exporter_version != "git" and ansible_userspace_bits == "32"
 
+- name: set internal variables for convenience
+  set_fact:
+    prometheus_node_exporter_tarball_url: "https://github.com/prometheus/node_exporter/archive/master.tar.gz"
+    prometheus_untar_path: /tmp
+  when: prometheus_node_exporter_version == "git"
 
+- name: delete the node_exporter directory if it already exists
+  file: path="{{ prometheus_download_path }}/node_exporter-master" state=absent
+  when: prometheus_node_exporter_version == "git"
 
 - name: download node_exporter tarball
-  get_url: url="{{ prometheus_node_exporter_tarball_url }}"  dest="{{ prometheus_download_path }}/node_exporter.tar.gz"
+  get_url: url="{{ prometheus_node_exporter_tarball_url }}" dest="{{ prometheus_download_path }}/node_exporter.tar.gz" force=yes
 
-- name: uutar node_exporter tarball
+- name: untar node_exporter tarball
   unarchive:
     src: "{{ prometheus_download_path }}/node_exporter.tar.gz"
-    dest: "{{ prometheus_install_path }}"
-    owner: "{{ prometheus_user }}"
-    group: "{{ prometheus_group }}"
-    mode: "go-w"
+    dest: "{{ prometheus_untar_path }}"
     copy: no
 
+- name: build node_exporter
+  command: make
+  args:
+    chdir: "{{ prometheus_download_path }}/node_exporter-master"
+    creates: node_exporter
+  when: prometheus_node_exporter_version == "git"
 
+- name: move the built node_exporter to the install path
+  command: "mv {{ prometheus_download_path }}/node_exporter-master/node_exporter {{ prometheus_install_path }}"
+  when: prometheus_node_exporter_version == "git"
+
+- name: set permissions, owner and group
+  file: path={{ prometheus_install_path }}/node_exporter owner={{ prometheus_user }} group={{ prometheus_group }} mode="go-w"
+
+- name: mkdir for data
+  file:
+    path: "{{ prometheus_db_path }}"
+    state: directory
+    owner: "{{ prometheus_user }}"
+    group: "{{ prometheus_group }}"
+    mode: "u=rwx,g=rx,o="
 
 - name: set node_exporter variables
   copy: src="../files/etc-default-node_exporter"  dest=/etc/default/node_exporter

--- a/tasks/install-node-exporter.yml
+++ b/tasks/install-node-exporter.yml
@@ -66,4 +66,4 @@
   template: src="../templates/node_exporter.sysvinit.{{ ansible_os_family|lower }}.sh.j2"  dest="/etc/init.d/node_exporter"  mode="a+x"
 
 - name: set INIT status
-  service: name=node_exporter enabled=yes state=started
+  service: name=node_exporter enabled=yes state=restarted

--- a/tasks/install-prometheus.yml
+++ b/tasks/install-prometheus.yml
@@ -21,11 +21,11 @@
 - name: set internal variables for convenience
   set_fact:
     prometheus_tarball_url: "https://github.com/prometheus/prometheus/archive/master.tar.gz"
-    prometheus_untar_path: /tmp
+    prometheus_untar_path: "{{ prometheus_download_path }}/prometheus_workdir/gopath/src/github.com/prometheus/prometheus"
   when: prometheus_version == "git"
 
 - name: delete the prometheus directory if it already exists
-  file: path="{{ prometheus_download_path }}/prometheus-master" state=absent
+  file: path="{{ prometheus_download_path }}/prometheus_workdir" state=absent
   when: prometheus_version == "git"
 
 - name: download prometheus tarball
@@ -37,15 +37,27 @@
     dest: "{{ prometheus_untar_path }}"
     copy: no
 
+- name: install temporary go
+  command: "{{ prometheus_untar_path }}/scripts/goenv.sh {{ prometheus_download_path }}/prometheus_workdir/go {{ prometheus_download_path }}/prometheus_workdir/gopath"
+  when: prometheus_version == "git"
+
 - name: build prometheus
-  command: make
+  command: make build
   args:
-    chdir: "{{ prometheus_download_path }}/prometheus-master"
+    chdir: "{{ prometheus_untar_path }}"
     creates: prometheus
+  environment:
+    GOPATH: "{{ prometheus_download_path }}/prometheus_workdir/gopath"
+    GOROOT: "{{ prometheus_download_path }}/prometheus_workdir/go"
   when: prometheus_version == "git"
 
 - name: move the built prometheus to the install path
-  command: "mv {{ prometheus_download_path }}/prometheus-master/prometheus {{ prometheus_install_path }}"
+  command: "mv {{ prometheus_untar_path }}/{{ item }} {{ prometheus_install_path }}"
+  with_items:
+    - prometheus
+    - promtool
+    - consoles
+    - console_libraries
   when: prometheus_version == "git"
 
 - name: mkdir for config and data

--- a/tasks/install-prometheus.yml
+++ b/tasks/install-prometheus.yml
@@ -6,18 +6,47 @@
 # @see http://prometheus.io/docs/introduction/getting_started/
 #
 
-
 - name: set internal variables for convenience
   set_fact:
     prometheus_tarball_url: "https://github.com/prometheus/prometheus/releases/download/{{ prometheus_version }}/prometheus-{{ prometheus_version }}.linux-amd64.tar.gz"
-  when: ansible_userspace_bits == "64"
+    prometheus_untar_path: "{{ prometheus_install_path }}"
+  when: prometheus_version != "git" and ansible_userspace_bits == "64"
 
 - name: set internal variables for convenience
   set_fact:
     prometheus_tarball_url: "https://github.com/prometheus/prometheus/releases/download/{{ prometheus_version }}/prometheus-{{ prometheus_version }}.linux-386.tar.gz"
-  when: ansible_userspace_bits == "32"
+    prometheus_untar_path: "{{ prometheus_install_path }}"
+  when: prometheus_version != "git" and ansible_userspace_bits == "32"
 
+- name: set internal variables for convenience
+  set_fact:
+    prometheus_tarball_url: "https://github.com/prometheus/prometheus/archive/master.tar.gz"
+    prometheus_untar_path: /tmp
+  when: prometheus_version == "git"
 
+- name: delete the prometheus directory if it already exists
+  file: path="{{ prometheus_download_path }}/prometheus-master" state=absent
+  when: prometheus_version == "git"
+
+- name: download prometheus tarball
+  get_url: url="{{ prometheus_tarball_url }}"  dest="{{ prometheus_download_path }}/prometheus.tar.gz"
+
+- name: untar prometheus tarball
+  unarchive:
+    src: "{{ prometheus_download_path }}/prometheus.tar.gz"
+    dest: "{{ prometheus_untar_path }}"
+    copy: no
+
+- name: build prometheus
+  command: make
+  args:
+    chdir: "{{ prometheus_download_path }}/prometheus-master"
+    creates: prometheus
+  when: prometheus_version == "git"
+
+- name: move the built prometheus to the install path
+  command: "mv {{ prometheus_download_path }}/prometheus-master/prometheus {{ prometheus_install_path }}"
+  when: prometheus_version == "git"
 
 - name: mkdir for config and data
   file:
@@ -31,23 +60,6 @@
     - "{{ prometheus_file_sd_config_path }}"
     - "{{ prometheus_db_path }}"
 
-
-
-
-- name: download prometheus tarball
-  get_url: url="{{ prometheus_tarball_url }}"  dest="{{ prometheus_download_path }}/prometheus.tar.gz"
-
-- name: uutar prometheus tarball
-  unarchive:
-    src: "{{ prometheus_download_path }}/prometheus.tar.gz"
-    dest: "{{ prometheus_install_path }}"
-    owner: "{{ prometheus_user }}"
-    group: "{{ prometheus_group }}"
-    mode: "go-w"
-    copy: no
-
-
-
 - name: set prometheus variables
   copy: src="../files/etc-default-prometheus"  dest=/etc/default/prometheus
 
@@ -56,8 +68,6 @@
 
 - name: set INIT status
   service: name=prometheus enabled=yes
-
-
 
 - name: copy prometheus main config file from role's default, if necessary
   template: src=../templates/prometheus.yml.j2  dest="{{ prometheus_config_path }}/prometheus.yml"

--- a/tasks/install-prometheus.yml
+++ b/tasks/install-prometheus.yml
@@ -24,10 +24,6 @@
     prometheus_untar_path: "{{ prometheus_download_path }}/prometheus_workdir/gopath/src/github.com/prometheus"
   when: prometheus_version == "git"
 
-- name: delete the prometheus directory if it already exists
-  file: path="{{ prometheus_download_path }}/prometheus_workdir" state=absent
-  when: prometheus_version == "git"
-
 - name: create initial directory structure
   file: path="{{ prometheus_untar_path }}" state=directory
   when: prometheus_version == "git"
@@ -119,3 +115,7 @@
   with_dict: prometheus_rule_files | default({})
   notify:
     - restart prometheus
+
+- name: delete the prometheus directory if it already exists
+  file: path="{{ prometheus_download_path }}/prometheus_workdir" state=absent
+  when: prometheus_version == "git"

--- a/tasks/install-prometheus.yml
+++ b/tasks/install-prometheus.yml
@@ -21,11 +21,15 @@
 - name: set internal variables for convenience
   set_fact:
     prometheus_tarball_url: "https://github.com/prometheus/prometheus/archive/master.tar.gz"
-    prometheus_untar_path: "{{ prometheus_download_path }}/prometheus_workdir/gopath/src/github.com/prometheus/prometheus"
+    prometheus_untar_path: "{{ prometheus_download_path }}/prometheus_workdir/gopath/src/github.com/prometheus"
   when: prometheus_version == "git"
 
 - name: delete the prometheus directory if it already exists
   file: path="{{ prometheus_download_path }}/prometheus_workdir" state=absent
+  when: prometheus_version == "git"
+
+- name: create initial directory structure
+  file: path="{{ prometheus_untar_path }}" state=directory
   when: prometheus_version == "git"
 
 - name: download prometheus tarball
@@ -37,14 +41,18 @@
     dest: "{{ prometheus_untar_path }}"
     copy: no
 
+- name: move prometheus-master to prometheus
+  command: "mv {{ prometheus_untar_path }}/prometheus-master {{ prometheus_untar_path }}/prometheus"
+  when: prometheus_version == "git"
+
 - name: install temporary go
-  command: "{{ prometheus_untar_path }}/scripts/goenv.sh {{ prometheus_download_path }}/prometheus_workdir/go {{ prometheus_download_path }}/prometheus_workdir/gopath"
+  command: "{{ prometheus_untar_path }}/prometheus/scripts/goenv.sh {{ prometheus_download_path }}/prometheus_workdir/go {{ prometheus_download_path }}/prometheus_workdir/gopath"
   when: prometheus_version == "git"
 
 - name: build prometheus
   command: make build
   args:
-    chdir: "{{ prometheus_untar_path }}"
+    chdir: "{{ prometheus_untar_path }}/prometheus"
     creates: prometheus
   environment:
     GOPATH: "{{ prometheus_download_path }}/prometheus_workdir/gopath"
@@ -52,7 +60,7 @@
   when: prometheus_version == "git"
 
 - name: move the built prometheus to the install path
-  command: "mv {{ prometheus_untar_path }}/{{ item }} {{ prometheus_install_path }}"
+  command: "mv {{ prometheus_untar_path }}/prometheus/{{ item }} {{ prometheus_install_path }}"
   with_items:
     - prometheus
     - promtool

--- a/tasks/install-prometheus.yml
+++ b/tasks/install-prometheus.yml
@@ -46,8 +46,13 @@
   when: prometheus_version == "git"
 
 - name: install temporary go
-  command: "{{ prometheus_untar_path }}/prometheus/scripts/goenv.sh {{ prometheus_download_path }}/prometheus_workdir/go {{ prometheus_download_path }}/prometheus_workdir/gopath"
+  shell: "{{ prometheus_untar_path }}/prometheus/scripts/goenv.sh {{ prometheus_download_path }}/prometheus_workdir/go {{ prometheus_download_path }}/prometheus_workdir/gopath"
   when: prometheus_version == "git"
+
+- name: determine installed go
+  command: "ls {{ prometheus_download_path }}/prometheus_workdir/go/"
+  when: prometheus_version == "git"
+  register: go_version
 
 - name: build prometheus
   command: make build
@@ -55,8 +60,16 @@
     chdir: "{{ prometheus_untar_path }}/prometheus"
     creates: prometheus
   environment:
+    PATH: "{{ ansible_env.PATH }}:{{ prometheus_download_path }}/prometheus_workdir/go/{{ go_version.stdout }}/bin"
     GOPATH: "{{ prometheus_download_path }}/prometheus_workdir/gopath"
-    GOROOT: "{{ prometheus_download_path }}/prometheus_workdir/go"
+    GOROOT: "{{ prometheus_download_path }}/prometheus_workdir/go/{{ go_version.stdout }}"
+  when: prometheus_version == "git"
+
+- name: remove existing consoles and console_libraries directories, if they exist
+  command: "rm -rf {{ prometheus_install_path }}/{{ item }}"
+  with_items:
+    - consoles
+    - console_libraries
   when: prometheus_version == "git"
 
 - name: move the built prometheus to the install path

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -9,11 +9,18 @@
 - name: set role variables, if necessary
   include: set-role-variables.yml
 
-
 - name: install libselinux-python binary for Ansible to work
   yum: name=libselinux-python state=present
   when: ansible_pkg_mgr == "yum"
 
+- name: install dependencies for installation of components from source
+  action: "{{ ansible_pkg_mgr }} name={{ item }} state=present"
+  when: prometheus_alertmanager_version == "git" or prometheus_node_exporter_version == "git" or prometheus_version == "git"
+  with_items:
+    - git
+    - mercurial
+    - gzip
+    - curl
 
 - name: create Prometheus group
   group: name=prometheus state=present


### PR DESCRIPTION
I needed to get a more recent version of Prometheus & AlertManager installed on our systems but there weren't yet releases cut for either of them. This PR adds the ability to get the source from Github and use the Prometheus provided Makefiles to download Go and compile Prometheus, AlertManager or node_exporter. It does not install Go to the system, merely uses it's own local copy temporarily.
