### PR TITLE
Add .DS_Store to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .vagrant
+.DS_Store


### PR DESCRIPTION
Fix for that pesky .DS_Store file that Finder on OS X generates.
