### PR TITLE
Use savagegus.consul instead of trumant.consul

### DIFF
--- a/requirements.yml
+++ b/requirements.yml
@@ -1,4 +1,3 @@
-- src: https://github.com/trumant/ansible-consul.git
-  version: 2bd5776c8f66e071500d7588547e8ab9ab103b03
+- src: savagegus.consul
   name: consul
   #path: /tmp/roles


### PR DESCRIPTION
trumant.consul uses bintray which seems to have had its consul packages pulled and moved to releases.hashicorp.com. savagegus.consul's the upstream role and already fixed this back in December.

This just resolves the consul_exporter test.
