### PR TITLE
Upload rules files before Prometheus config.

### DIFF
--- a/tasks/install-prometheus.yml
+++ b/tasks/install-prometheus.yml
@@ -110,6 +110,15 @@
 - name: set INIT status
   service: name=prometheus enabled=yes
 
+- name: copy rule files from playbook's, if any
+  copy:
+    src: "{{ playbook_dir }}/{{ item.value.src }}"
+    dest: "{{ prometheus_rule_path }}/{{ item.value.dest }}"
+    validate: "{{ prometheus_daemon_dir }}/promtool check-rules %s"
+  with_dict: '{{ prometheus_rule_files | default({}) }}'
+  notify:
+    - reload prometheus
+
 - name: copy prometheus main config file from role's default, if necessary
   template:
     src: "../templates/prometheus.yml.j2"
@@ -125,14 +134,5 @@
     dest: "{{ prometheus_config_path }}/prometheus.yml"
     validate: "{{ prometheus_daemon_dir }}/promtool check-config %s"
   when: prometheus_conf_main is defined
-  notify:
-    - reload prometheus
-
-- name: copy rule files from playbook's, if any
-  copy:
-    src: "{{ playbook_dir }}/{{ item.value.src }}"
-    dest: "{{ prometheus_rule_path }}/{{ item.value.dest }}"
-    validate: "{{ prometheus_daemon_dir }}/promtool check-rules %s"
-  with_dict: '{{ prometheus_rule_files | default({}) }}'
   notify:
     - reload prometheus


### PR DESCRIPTION
Ansible runs error out when validating Prometheus' main config if the rule file(s) it expects do not exist, so this uploads them beforehand.
