### PR TITLE
Fix order to ensure rules pass check

### DIFF
--- a/tasks/install-prometheus.yml
+++ b/tasks/install-prometheus.yml
@@ -124,6 +124,15 @@
 - name: set INIT status
   service: name=prometheus enabled=yes
 
+- name: copy rule files from playbook's, if any
+  copy:
+    src: "{{ playbook_dir }}/{{ item.value.src }}"
+    dest: "{{ prometheus_rule_path }}/{{ item.value.dest }}"
+    validate: "{{ prometheus_daemon_dir }}/promtool check-rules %s"
+  with_dict: '{{ prometheus_rule_files | default({}) }}'
+  notify:
+    - reload prometheus
+
 - name: copy prometheus main config file from role's default, if necessary
   template:
     src: "../templates/prometheus.yml.j2"
@@ -142,11 +151,3 @@
   notify:
     - reload prometheus
 
-- name: copy rule files from playbook's, if any
-  copy:
-    src: "{{ playbook_dir }}/{{ item.value.src }}"
-    dest: "{{ prometheus_rule_path }}/{{ item.value.dest }}"
-    validate: "{{ prometheus_daemon_dir }}/promtool check-rules %s"
-  with_dict: '{{ prometheus_rule_files | default({}) }}'
-  notify:
-    - reload prometheus


### PR DESCRIPTION
In order to ensure that the config check passes, the order should be switched, in case of includes.
