### PR TITLE
Add complete systemd support

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,8 +87,7 @@ gosu_version:  "1.10"
 If the Linux distributions are equipped with systemd, this role will use this mechanism accordingly. You can disable this (i.e., use traditional SysV-style init script) by defining the following variable(s) to `false`:
 
 ```yaml
-# currently, only node_exporter is supported.
-prometheus_node_exporter_use_systemd
+prometheus_use_systemd
 ```
 
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -51,4 +51,4 @@ prometheus_rebuild:           false
 
 #---- the following vars are handled in tasks/set-role-variables.yml ------
 
-#prometheus_node_exporter_use_systemd: False  # use "systemd" to start/restart service?
+#prometheus_use_systemd: False  # use "systemd" to start/restart service?

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -2,6 +2,11 @@
 # file: handlers/main.yml
 #
 
+- name: reload systemd
+  systemd:
+    name: prometheus
+    daemon_reload: yes
+
 - name: restart prometheus
   service: name=prometheus state=restarted
   when: prometheus_use_service|bool

--- a/tasks/install-alertmanager.yml
+++ b/tasks/install-alertmanager.yml
@@ -109,8 +109,16 @@
 - name: set alertmanager variables
   copy: src="../files/etc-default-alertmanager"  dest=/etc/default/alertmanager
 
+- name: copy systemd config to server
+  template: src="../templates/alertmanager.service.j2"  dest="/etc/systemd/system/alertmanager.service"
+  when: prometheus_use_systemd
+  notify:
+    - reload systemd
+    - restart alertmanager
+
 - name: copy INIT script to server
   template: src="../templates/alertmanager.sysvinit.{{ ansible_os_family|lower }}.sh.j2"  dest="/etc/init.d/alertmanager"  mode="a+x"
+  when: not prometheus_use_systemd|bool
 
 - name: set INIT status
   service: name=alertmanager enabled=yes

--- a/tasks/install-node-exporter.yml
+++ b/tasks/install-node-exporter.yml
@@ -105,12 +105,14 @@
 
 - name: copy INIT script to server
   template: src="../templates/node_exporter.sysvinit.{{ ansible_os_family|lower }}.sh.j2"  dest="/etc/init.d/node_exporter"  mode="a+x"
-  when: not prometheus_node_exporter_use_systemd|bool
+  when: not prometheus_use_systemd|bool
 
 - name: copy systemd config to server
-  template: src="../templates/node_exporter.service.j2"  dest="/lib/systemd/system/node_exporter.service"
-  when: prometheus_node_exporter_use_systemd|bool
-
+  template: src="../templates/node_exporter.service.j2"  dest="/etc/systemd/system/node_exporter.service"
+  when: prometheus_use_systemd|bool
+  notify:
+    - reload systemd
+    - restart node_exporter
 
 - name: set INIT status and start
   service: name=node_exporter enabled=yes state=started

--- a/tasks/install-prometheus.yml
+++ b/tasks/install-prometheus.yml
@@ -107,8 +107,16 @@
 - name: set prometheus variables
   copy: src="../files/etc-default-prometheus"  dest=/etc/default/prometheus
 
+- name: copy systemd config to server
+  template: src="../templates/prometheus.service.j2"  dest="/etc/systemd/system/prometheus.service"
+  when: prometheus_use_systemd
+  notify:
+    - reload systemd
+    - restart prometheus
+
 - name: copy INIT script to server
   template: src="../templates/prometheus.sysvinit.{{ ansible_os_family|lower }}.sh.j2"  dest="/etc/init.d/prometheus"  mode="a+x"
+  when: not prometheus_use_systemd|bool
 
 - name: set INIT status
   service: name=prometheus enabled=yes

--- a/tasks/set-role-variables.yml
+++ b/tasks/set-role-variables.yml
@@ -24,28 +24,28 @@
 
   - name: use systemd for CentOS >= 7
     set_fact:
-      prometheus_node_exporter_use_systemd: true
+      prometheus_use_systemd: true
     when: ansible_distribution == "CentOS" and ansible_distribution_version|int >= 7
 
   - name: use systemd for RHEL >= 7
     set_fact:
-      prometheus_node_exporter_use_systemd: true
+      prometheus_use_systemd: true
     when: ansible_distribution == "Red Hat Enterprise Linux" and ansible_distribution_version|int >= 7
 
   - name: use systemd for Debian >= 8
     set_fact:
-      prometheus_node_exporter_use_systemd: true
+      prometheus_use_systemd: true
     when: ansible_distribution == "Debian" and ansible_distribution_version|int >= 8
 
   - name: use systemd for Ubuntu >= 16.04
     set_fact:
-      prometheus_node_exporter_use_systemd: true
+      prometheus_use_systemd: true
     when: ansible_distribution == "Ubuntu" and ansible_distribution_version|int >= 16
 
-  when: prometheus_node_exporter_use_systemd is not defined
+  when: prometheus_use_systemd is not defined
 
 
 - name: use traditional SysV init, otherwise
   set_fact:
-    prometheus_node_exporter_use_systemd: false
-  when: prometheus_node_exporter_use_systemd is not defined
+    prometheus_use_systemd: false
+  when: prometheus_use_systemd is not defined

--- a/templates/alertmanager.service.j2
+++ b/templates/alertmanager.service.j2
@@ -1,0 +1,18 @@
+[Unit]
+Description=Prometheus Alertmanager
+After=network.target
+
+[Service]
+ExecStart={{ prometheus_alertmanager_daemon_dir }}/alertmanager \
+    -config.file={{ prometheus_config_path }}/alertmanager.yml \
+    -storage.path={{ prometheus_alertmanager_db_path }} \
+    {{ prometheus_alertmanager_opts | default() }}
+KillMode=process
+User={{ prometheus_user }}
+Group={{ prometheus_group }}
+Restart=on-failure
+ExecReload=/bin/kill -SIGHUP $MAINPID
+
+[Install]
+WantedBy=multi-user.target
+

--- a/templates/prometheus.service.j2
+++ b/templates/prometheus.service.j2
@@ -1,0 +1,29 @@
+{% if prometheus_alertmanager_url is defined %}
+{% set alertmanager_service_opts = '-alertmanager.url=' + prometheus_alertmanager_url %}
+{% else %}
+{% set alertmanager_service_opts = '' %}
+{% endif %}
+
+[Unit]
+Description=Prometheus Server
+After=network.target
+
+[Service]
+ExecStart={{ prometheus_daemon_dir }}/prometheus \
+    -config.file={{ prometheus_config_path }}/prometheus.yml \
+    {{ alertmanager_service_opts }} \
+    -web.console.templates={{ prometheus_daemon_dir }}/consoles \
+    -web.console.libraries={{ prometheus_daemon_dir }}/console_libraries \
+    -storage.local.path={{ prometheus_db_path }} \
+    {{ prometheus_opts | default() }}
+KillMode=process
+User={{ prometheus_user }}
+Group={{ prometheus_group }}
+Restart=on-failure
+ExecReload=/bin/kill -SIGHUP $MAINPID
+
+[Install]
+WantedBy=multi-user.target
+
+# Removed args
+# -web.hostname=https://prometheus.scypho-backend.se \

--- a/test/Dockerfile-debian8
+++ b/test/Dockerfile-debian8
@@ -15,7 +15,7 @@ MAINTAINER William Yeh <william.pjyeh@gmail.com>
 #
 
 ENV PLAYBOOK test.yml
-RUN ansible-playbook-wrapper --extra-vars "prometheus_node_exporter_use_systemd=false"
+RUN ansible-playbook-wrapper --extra-vars "prometheus_use_systemd=false"
 
 
 

--- a/test/Dockerfile-debian8-git
+++ b/test/Dockerfile-debian8-git
@@ -18,7 +18,7 @@ ENV PLAYBOOK test.yml
 RUN sed -i -e 's/^\(prometheus_version:\).*$/\1 git/'                defaults/main.yml
 RUN sed -i -e 's/^\(prometheus_node_exporter_version:\).*$/\1 git/'  defaults/main.yml
 RUN sed -i -e 's/^\(prometheus_alertmanager_version:\).*$/\1 git/'   defaults/main.yml
-RUN ansible-playbook-wrapper --extra-vars "prometheus_node_exporter_use_systemd=false"
+RUN ansible-playbook-wrapper --extra-vars "prometheus_use_systemd=false"
 
 
 

--- a/test/Dockerfile-ubuntu16.04
+++ b/test/Dockerfile-ubuntu16.04
@@ -18,7 +18,7 @@ ENV PLAYBOOK test.yml
 RUN echo "===> Installing git for ansible galaxy..."  && \
     DEBIAN_FRONTEND=noninteractive  \
     apt-get install -y -f git
-RUN ansible-playbook-wrapper -e 'prometheus_node_exporter_use_systemd=false'
+RUN ansible-playbook-wrapper -e 'prometheus_use_systemd=false'
 
 
 

--- a/test/Dockerfile-ubuntu16.04-git
+++ b/test/Dockerfile-ubuntu16.04-git
@@ -21,7 +21,7 @@ RUN echo "===> Installing git for ansible galaxy..."  && \
 RUN sed -i -e 's/^\(prometheus_version:\).*$/\1 git/'                  defaults/main.yml
 RUN sed -i -e 's/^\(prometheus_node_exporter_version:\).*$/\1 git/'    defaults/main.yml
 RUN sed -i -e 's/^\(prometheus_alertmanager_version:\).*$/\1 git/'     defaults/main.yml
-RUN ansible-playbook-wrapper -e 'prometheus_node_exporter_use_systemd=false'
+RUN ansible-playbook-wrapper -e 'prometheus_use_systemd=false'
 
 
 


### PR DESCRIPTION
Now both alertmanager and prometheus have support for systemd.

This patch also contains a breaking change where it removes the flag
prometheus_node_exporter_use_systemd in favour of
prometheus_use_systemd, that configures all three services.

This solves issue #30