### PR TITLE
Add: enable node_exporter in systemd

### DIFF
--- a/tasks/install-node-exporter.yml
+++ b/tasks/install-node-exporter.yml
@@ -105,3 +105,7 @@
 
 - name: set INIT status and start
   service: name=node_exporter enabled=yes state=started
+
+- name: set systemd status and start
+  systemd: name=node_exporter enabled=yes state=started
+

--- a/templates/node_exporter.service.j2
+++ b/templates/node_exporter.service.j2
@@ -19,3 +19,6 @@ ExecStart={{ prometheus_node_exporter_daemon_dir }}/node_exporter  {{ prometheus
 {% else %}
 ExecStart={{ prometheus_node_exporter_daemon_dir }}/node_exporter
 {% endif %}
+
+[Install]
+WantedBy=default.target


### PR DESCRIPTION
Using systemd to enable "node_exporter.service" and adding the "[Install]"-section to enable starting at boot time.