### PR TITLE
Add: enable starting node_exporter on reboots in systemd

### DIFF
--- a/tasks/install-node-exporter.yml
+++ b/tasks/install-node-exporter.yml
@@ -105,3 +105,8 @@
 
 - name: set INIT status and start
   service: name=node_exporter enabled=yes state=started
+  when: not prometheus_node_exporter_use_systemd|bool
+
+- name: set systemd status and start
+  systemd: name=node_expoerter enabled=yes state=started
+  when: prometheus_node_exporter_use_systemd

--- a/templates/node_exporter.service.j2
+++ b/templates/node_exporter.service.j2
@@ -19,3 +19,6 @@ ExecStart={{ prometheus_node_exporter_daemon_dir }}/node_exporter  {{ prometheus
 {% else %}
 ExecStart={{ prometheus_node_exporter_daemon_dir }}/node_exporter
 {% endif %}
+
+[Install]
+WantedBy=default.task


### PR DESCRIPTION
- added [Install] section in node_exporter.service --> this enables start on machine-boot
- corrections and additions to systemd-specific tasks for node_exporter
