### PR TITLE
Add the possibility to make prometheus user a system user

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -12,6 +12,7 @@
 
 prometheus_user:   prometheus
 prometheus_group:  prometheus
+prometheus_user_system: no
 
 prometheus_version:                 1.5.0
 prometheus_node_exporter_version:   0.13.0

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -30,6 +30,7 @@
     shell: /sbin/nologin
     comment: "Prometheus User"
     state: present
+    system: "{{ prometheus_user_system }}"
 
 - name: mkdir for general cases
   file:


### PR DESCRIPTION
The user should have the possibility to create promtheus user as system user. This PR aims to let the user do that.