### PR TITLE
Treat RHEL-based Virtuozzo OS like and CentOS

### DIFF
--- a/tasks/install-node-exporter.yml
+++ b/tasks/install-node-exporter.yml
@@ -109,7 +109,12 @@
 
 - name: copy systemd config to server
   template: src="../templates/node_exporter.service.j2"  dest="/lib/systemd/system/node_exporter.service"
+  register: prometheus_node_exporter_unit_file
   when: prometheus_node_exporter_use_systemd|bool
+
+- name: reload systemd for new unit file
+  command: systemctl daemon-reload
+  when: prometheus_node_exporter_unit_file.changed
 
 
 - name: set INIT status and start

--- a/tasks/set-role-variables.yml
+++ b/tasks/set-role-variables.yml
@@ -32,6 +32,11 @@
       prometheus_node_exporter_use_systemd: true
     when: ansible_distribution == "Red Hat Enterprise Linux" and ansible_distribution_version|int >= 7
 
+  - name: use systemd for Virtuozzo >= 7
+    set_fact:
+      prometheus_node_exporter_use_systemd: true
+    when: ansible_distribution == "Virtuozzo" and ansible_distribution_version|int >= 7
+
   - name: use systemd for Debian >= 8
     set_fact:
       prometheus_node_exporter_use_systemd: true


### PR DESCRIPTION
Virtuozzo 7+ and OpenVZ 7+ are built on the same OS - with a customised kernel (and various user space tweaks) to support running containers and VMs https://openvz.org/Virtuozzo

For the purposes of Prometheus it can be treated the same as RHEL 7 and CentOS 7.