### PR TITLE
Fix idempotence for fixed versions

### DIFF
--- a/tasks/install-alertmanager.yml
+++ b/tasks/install-alertmanager.yml
@@ -36,6 +36,7 @@
       unarchive:
         src: "{{ prometheus_alertmanager_tarball_url }}"
         dest: "{{ prometheus_alertmanager_untar_path }}"
+        creates: "{{prometheus_install_path}}/alertmanager-{{prometheus_alertmanager_version}}.linux-{{ (ansible_userspace_bits == '32') | ternary('386', 'amd64') }}"
         copy: no
         owner: "{{ prometheus_user }}"
         group: "{{ prometheus_group }}"

--- a/tasks/install-node-exporter.yml
+++ b/tasks/install-node-exporter.yml
@@ -37,6 +37,7 @@
       unarchive:
         src: "{{ prometheus_node_exporter_tarball_url }}"
         dest: "{{ prometheus_install_path }}"
+        creates: "{{prometheus_install_path}}/node_exporter-{{prometheus_node_exporter_version}}.linux-{{ (ansible_userspace_bits == '32') | ternary('386', 'amd64') }}"
         copy: no
 
   when: prometheus_node_exporter_version != "git"

--- a/tasks/install-prometheus.yml
+++ b/tasks/install-prometheus.yml
@@ -37,6 +37,7 @@
       unarchive:
         src: "{{ prometheus_tarball_url }}"
         dest: "{{ prometheus_install_path }}"
+        creates: "{{prometheus_install_path}}/prometheus-{{prometheus_version}}.linux-{{ (ansible_userspace_bits == '32') | ternary('386', 'amd64') }}"
         copy: no
 
   when: prometheus_version != "git"


### PR DESCRIPTION
These small changes allow to pass the idempotency tests for fixed versions of the Prometheus applications. 

The original 'download and uncompress' and 'set permissions' tasks always return a changed status despite the binaries are in place with the correct permissions, with these changes both tasks skip the actions if the all the binaries are set.