### PR TITLE
Update Vagrantfile

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -16,9 +16,9 @@ Vagrant.configure(2) do |config|
         end
 
         # Prometheus server UI port
-        node.vm.network :forwarded_port, guest: 9090, host: 9090
+        node.vm.network :forwarded_port, guest: 9090, host: 9090, host_ip: "127.0.0.1", auto_correct: true
         # Alertmanager UI port
-        node.vm.network :forwarded_port, guest: 9093, host: 9093
+        node.vm.network :forwarded_port, guest: 9093, host: 9093, host_ip: "127.0.0.1", auto_correct: true
 
 
        node.vm.provider "virtualbox" do |vb|


### PR DESCRIPTION
There is an issue with the new vagrant 1.9.3 (see https://github.com/mitchellh/vagrant/issues/8395). It can be solved by adding: host_ip: "127.0.0.1"

It will solve below error:
The requested address is not valid in its context. - connect(2) for "0.0.0.0" port 9090 (Errno::EADDRNOTAVAIL)