### PR TITLE
Fix: promtool 'check rules' and 'check config' commands are valid starting from 2.0.0 release

### DIFF
--- a/tasks/install-prometheus.yml
+++ b/tasks/install-prometheus.yml
@@ -39,6 +39,18 @@
         dest: "{{ prometheus_install_path }}"
         copy: no
 
+    - name: set promtool check commands for >= 2.0.0
+      set_fact:
+        promtool_check_config_command: check config
+        promtool_check_rules_command: check rules
+      when: prometheus_version | version_compare('2.0', '>=')
+
+    - name: set promtool check commands for < 2.0.0
+      set_fact:
+        promtool_check_config_command: check-config
+        promtool_check_rules_command: check-rules
+      when: prometheus_version | version_compare('2.0', '<')
+
   when: prometheus_version != "git"
 
 
@@ -49,6 +61,8 @@
         prometheus_git_url: "https://github.com/prometheus/prometheus.git"
         prometheus_src_path: "{{ prometheus_goroot }}/src/github.com/prometheus/prometheus"
         prometheus_daemon_dir: "{{ prometheus_install_path }}"
+        promtool_check_config_command: check config
+        promtool_check_rules_command: check rules
 
     - name: delete the prometheus build directory, if necessary
       file: path="{{ prometheus_src_path }}" state=absent
@@ -119,7 +133,7 @@
   copy:
     src: "{{ playbook_dir }}/{{ item.value.src }}"
     dest: "{{ prometheus_rule_path }}/{{ item.value.dest }}"
-    validate: "{{ prometheus_daemon_dir }}/promtool check-rules %s"
+    validate: "{{ prometheus_daemon_dir }}/promtool {{ promtool_check_rules_command }} %s"
   with_dict: '{{ prometheus_rule_files | default({}) }}'
   notify:
     - reload prometheus
@@ -128,7 +142,7 @@
   template:
     src: "../templates/prometheus.yml.j2"
     dest: "{{ prometheus_config_path }}/prometheus.yml"
-    validate: "{{ prometheus_daemon_dir }}/promtool check-config %s"
+    validate: "{{ prometheus_daemon_dir }}/promtool {{ promtool_check_config_command }} %s"
   when: prometheus_conf_main is not defined
   notify:
     - reload prometheus
@@ -137,7 +151,7 @@
   template:
     src: "{{ playbook_dir }}/{{ prometheus_conf_main }}"
     dest: "{{ prometheus_config_path }}/prometheus.yml"
-    validate: "{{ prometheus_daemon_dir }}/promtool check-config %s"
+    validate: "{{ prometheus_daemon_dir }}/promtool {{ promtool_check_config_command }} %s"
   when: prometheus_conf_main is defined
   notify:
     - reload prometheus


### PR DESCRIPTION
In new 2.x.x prometheus promtool command line arguments has changed and backward compatibility has been broken.

was

```
promtool check-rules
promtool check-config
```

now

```
promtool check rules
promtool check config
```

This pull request fixes this issue by providing new conditional facts.