### PR TITLE
fix Using tests as filters is deprecated warnings

### DIFF
--- a/tasks/install-alertmanager.yml
+++ b/tasks/install-alertmanager.yml
@@ -23,12 +23,12 @@
     - name: set download url for versions >= 0.3.0
       set_fact:
         prometheus_alertmanager_tarball_url: "https://github.com/prometheus/alertmanager/releases/download/v{{ prometheus_alertmanager_version }}/{{ prometheus_alertmanager_signature }}.tar.gz"
-      when: prometheus_alertmanager_version | version_compare('0.3', '>=')
+      when: prometheus_alertmanager_version is version_compare('0.3', '>=')
 
     - name: set download url for versions < 0.3.0 (OBSOLETE!)
       set_fact:
         prometheus_alertmanager_tarball_url: "https://github.com/prometheus/alertmanager/releases/download/{{ prometheus_alertmanager_version }}/{{ prometheus_alertmanager_signature }}.tar.gz"
-      when: prometheus_alertmanager_version | version_compare('0.3', '<')
+      when: prometheus_alertmanager_version is version_compare('0.3', '<')
 
 
 

--- a/tasks/install-node-exporter.yml
+++ b/tasks/install-node-exporter.yml
@@ -16,22 +16,22 @@
     - name: set download url for versions >= 0.13.0
       set_fact:
         prometheus_node_exporter_tarball_url: "https://github.com/prometheus/node_exporter/releases/download/v{{ prometheus_node_exporter_version }}/node_exporter-{{ prometheus_node_exporter_version }}.{{ prometheus_platform_suffix }}.tar.gz"
-      when: prometheus_node_exporter_version | version_compare('0.13.0', '>=')
+      when: prometheus_node_exporter_version is version_compare('0.13.0', '>=')
 
     - name: set download url for versions < 0.13.0 (OBSOLETE!)
       set_fact:
         prometheus_node_exporter_tarball_url: "https://github.com/prometheus/node_exporter/releases/download/{{ prometheus_node_exporter_version }}/node_exporter-{{ prometheus_node_exporter_version }}.{{ prometheus_platform_suffix }}.tar.gz"
-      when: prometheus_node_exporter_version | version_compare('0.13.0', '<')
+      when: prometheus_node_exporter_version is version_compare('0.13.0', '<')
 
     - name: set daemon dir for versions >= 0.12
       set_fact:
         prometheus_node_exporter_daemon_dir: "{{ prometheus_node_exporter_subdir }}"
-      when: prometheus_node_exporter_version | version_compare('0.12', '>=')
+      when: prometheus_node_exporter_version is version_compare('0.12', '>=')
 
     - name: set daemon dir for versions < 0.12 (OBSOLETE!)
       set_fact:
         prometheus_node_exporter_daemon_dir: "{{ prometheus_install_path }}"
-      when: prometheus_node_exporter_version | version_compare('0.12', '<')
+      when: prometheus_node_exporter_version is version_compare('0.12', '<')
 
     - name: download and untar node_exporter tarball
       unarchive:

--- a/tasks/install-prometheus.yml
+++ b/tasks/install-prometheus.yml
@@ -16,22 +16,22 @@
     - name: set download url for versions >= 1.0.0
       set_fact:
         prometheus_tarball_url: "https://github.com/prometheus/prometheus/releases/download/v{{ prometheus_version }}/prometheus-{{ prometheus_version }}.{{ prometheus_platform_suffix }}.tar.gz"
-      when: prometheus_version | version_compare('1.0', '>=')
+      when: prometheus_version is version_compare('1.0', '>=')
 
     - name: set download url for versions < 1.0.0
       set_fact:
         prometheus_tarball_url: "https://github.com/prometheus/prometheus/releases/download/{{ prometheus_version }}/prometheus-{{ prometheus_version }}.{{ prometheus_platform_suffix }}.tar.gz"
-      when: prometheus_version | version_compare('1.0', '<')
+      when: prometheus_version is version_compare('1.0', '<')
 
     - name: set daemon dir for versions >= 0.16
       set_fact:
         prometheus_daemon_dir: "{{ prometheus_subdir }}"
-      when: prometheus_version | version_compare('0.16', '>=')
+      when: prometheus_version is version_compare('0.16', '>=')
 
     - name: set daemon dir for versions < 0.16 (OBSOLETE!)
       set_fact:
         prometheus_daemon_dir: "{{ prometheus_install_path }}"
-      when: prometheus_version | version_compare('0.16', '<')
+      when: prometheus_version is version_compare('0.16', '<')
 
     - name: download and untar prometheus tarball
       unarchive:


### PR DESCRIPTION
This PR will fix the 'Using tests as filters is deprecated'  warnings 

example warning:
``[williamyeh.prometheus : set download url for versions >= 0.3.0] **********
[DEPRECATION WARNING]: Using tests as filters is deprecated. Instead of using
`result|version_compare` instead use `result is version_compare`. This feature
will be removed in version 2.9. Deprecation warnings can be disabled by setting
 deprecation_warnings=False in ansible.cfg.``
