### PR TITLE
Update prometheus, node exporter, and alertmanager versions to latest

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -13,9 +13,9 @@
 prometheus_user:   prometheus
 prometheus_group:  prometheus
 
-prometheus_version:                 2.5.0
-prometheus_node_exporter_version:   0.16.0
-prometheus_alertmanager_version:    0.15.3
+prometheus_version:                 2.10.0
+prometheus_node_exporter_version:   0.18.1
+prometheus_alertmanager_version:    0.17.0
 
 gosu_version: "1.11"
 prometheus_go_version:   1.11


### PR DESCRIPTION
This commit makes use of the latest Prometheus, Node exporter, and Alertmanager releases as of writing.