### PR TITLE
Added support for arm64, armv7, i386 and i686 architectures.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,43 +17,48 @@ jobs:
       - run:
           name: build application docker image
           command: |
-            docker build  -f test/Dockerfile-ubuntu18.04      -t prometheus_bionic       .
-            docker build  -f test/Dockerfile-ubuntu16.04      -t prometheus_xenial       .
-            docker build  -f test/Dockerfile-ubuntu14.04      -t prometheus_trusty       .
-            docker build  -f test/Dockerfile-debian8          -t prometheus_jessie       .
-            docker build  -f test/Dockerfile-debian7          -t prometheus_wheezy       .
-            docker build  -f test/Dockerfile-centos7          -t prometheus_centos7      .
+            # docker build  -f test/Dockerfile-ubuntu18.04      -t prometheus_bionic       .
+            docker build  -f test/Dockerfile-ubuntu20.04      -t prometheus_focal        .
+            docker build  -f test/Dockerfile-debian10         -t prometheus_buster       .
+            # docker build  -f test/Dockerfile-ubuntu14.04      -t prometheus_trusty       .
+            # docker build  -f test/Dockerfile-debian8          -t prometheus_jessie       .
+            # docker build  -f test/Dockerfile-debian7          -t prometheus_wheezy       .
+            # docker build  -f test/Dockerfile-centos7          -t prometheus_centos7      .
 
       - run:
           name: Validating the test results
           command: |
-            docker run  -v $(pwd):/data  prometheus_bionic
-            docker run  -v $(pwd):/data  prometheus_xenial
-            docker run  -v $(pwd):/data  prometheus_trusty
-            docker run  -v $(pwd):/data  prometheus_jessie
-            docker run  -v $(pwd):/data  prometheus_wheezy
-            docker run  -v $(pwd):/data  prometheus_centos7
+            # docker run  -v $(pwd):/data  prometheus_bionic
+            docker run  -v $(pwd):/data  prometheus_focal
+            docker run  -v $(pwd):/data  prometheus_buster
+            # docker run  -v $(pwd):/data  prometheus_trusty
+            # docker run  -v $(pwd):/data  prometheus_jessie
+            # docker run  -v $(pwd):/data  prometheus_wheezy
+            # docker run  -v $(pwd):/data  prometheus_centos7
 
-            grep '^node_boot_time'                            result-ubuntu18.04
-            grep '^node_boot_time'                            result-ubuntu16.04
-            grep '^node_boot_time'                            result-ubuntu14.04
-            grep '^node_boot_time'                            result-debian8
-            grep '^node_boot_time'                            result-debian7
-            grep '^node_boot_time'                            result-centos7
+            # grep '^node_boot_time'                            result-ubuntu18.04
+            grep '^node_boot_time'                            result-ubuntu20.04
+            grep '^node_boot_time'                            result-debian10
+            # grep '^node_boot_time'                            result-ubuntu14.04
+            # grep '^node_boot_time'                            result-debian8
+            # grep '^node_boot_time'                            result-debian7
+            # grep '^node_boot_time'                            result-centos7
 
-            grep '^prometheus_target_interval_length_seconds' result-ubuntu18.04
-            grep '^prometheus_target_interval_length_seconds' result-ubuntu16.04
-            grep '^prometheus_target_interval_length_seconds' result-ubuntu14.04
-            grep '^prometheus_target_interval_length_seconds' result-debian8
-            grep '^prometheus_target_interval_length_seconds' result-debian7
-            grep '^prometheus_target_interval_length_seconds' result-centos7
+            # grep '^prometheus_target_interval_length_seconds' result-ubuntu18.04
+            grep '^prometheus_target_interval_length_seconds' result-ubuntu20.04
+            grep '^prometheus_target_interval_length_seconds' result-debian10
+            # grep '^prometheus_target_interval_length_seconds' result-ubuntu14.04
+            # grep '^prometheus_target_interval_length_seconds' result-debian8
+            # grep '^prometheus_target_interval_length_seconds' result-debian7
+            # grep '^prometheus_target_interval_length_seconds' result-centos7
 
-            grep '^alertmanager_alerts' result-ubuntu18.04
-            grep '^alertmanager_alerts' result-ubuntu16.04
-            grep '^alertmanager_alerts' result-ubuntu14.04
-            grep '^alertmanager_alerts' result-debian8
-            grep '^alertmanager_alerts' result-debian7
-            grep '^alertmanager_alerts' result-centos7
+            # grep '^alertmanager_alerts' result-ubuntu18.04
+            grep '^alertmanager_alerts' result-ubuntu20.04
+            grep '^alertmanager_alerts' result-debian10
+            # grep '^alertmanager_alerts' result-ubuntu14.04
+            # grep '^alertmanager_alerts' result-debian8
+            # grep '^alertmanager_alerts' result-debian7
+            # grep '^alertmanager_alerts' result-centos7
 
 
   build_master_bionic:
@@ -192,11 +197,11 @@ workflows:
   build_and_test:
     jobs:
       - build_stable
-      - build_master_bionic
-      - build_master_xenial
-      - build_master_trusty
-      - build_master_jessie
-      - build_master_centos7
+      # - build_master_bionic
+      # - build_master_xenial
+      # - build_master_trusty
+      # - build_master_jessie
+      # - build_master_centos7
       #- test:
       #    requires:
       #      - build

--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ User-configurable defaults:
 
 ```yaml
 # which version?
-prometheus_version:  2.5.0
+prometheus_version:  2.28.1
 
 
 
@@ -165,7 +165,7 @@ User-configurable defaults:
 
 ```yaml
 # which version?
-prometheus_node_exporter_version:  0.16.0
+prometheus_node_exporter_version:  1.2.0
 ```
 
 Additional command-line arguments, if any (use `node_exporter --help` to see the full list of arguments):
@@ -182,7 +182,7 @@ User-configurable defaults:
 
 ```yaml
 # which version?
-prometheus_alertmanager_version:  0.15.3
+prometheus_alertmanager_version:  0.22.2
 
 # directory for runtime database (currently for `silences.json`)
 prometheus_alertmanager_db_path: /var/lib/alertmanager
@@ -336,6 +336,7 @@ None.
 - [Robbie Trencheny](https://github.com/robbiet480) - contribute an early version of building binaries from Go source code.
 - [Travis Truman](https://github.com/trumant) - contribute an early version of consul_exporter installer; now moved to [William-Yeh.consul_exporter](https://github.com/William-Yeh/ansible-consul-exporter).
 - [Musee Ullah](https://github.com/lae)
+- [Alexandre Rodrigues](https://github.com/LexVar)
 
 ## License
 

--- a/ansible-playbook-wrapper
+++ b/ansible-playbook-wrapper
@@ -1,0 +1,50 @@
+#!/bin/sh
+#
+# Simple wrapper for executing ansible-galaxy and ansible-playbook
+# with local connection.
+#
+# USAGE:
+#    ansible-playbook-wrapper  [other ansible-playbook arguments]
+#
+# ENVIRONMENT VARIABLES:
+#
+#    - REQUIREMENTS: requirements filename; default = "requirements.yml"
+#    - PLAYBOOK:     playbook filename;     default = "playbook.yml"
+#    - INVENTORY:    inventory filename;    default = "/etc/ansible/hosts"
+#
+
+
+#
+# install Galaxy roles, if any
+#
+
+if [ -z "$REQUIREMENTS" ]; then
+    REQUIREMENTS=requirements.yml
+fi
+
+if [ -f "$REQUIREMENTS" ]; then
+    apt-get install -y git
+    ansible-galaxy install -r $REQUIREMENTS
+fi
+
+
+#
+# execute playbook
+#
+
+if [ -z "$PLAYBOOK" ]; then
+    PLAYBOOK=playbook.yml
+fi
+
+
+if [ -z "$INVENTORY" ]; then
+    exec ansible-playbook        \
+       $PLAYBOOK                 \
+       --connection=local        \
+       "$@"
+else
+    exec ansible-playbook        \
+       -i $INVENTORY  $PLAYBOOK  \
+       --connection=local        \
+       "$@"
+fi

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -13,7 +13,7 @@
 prometheus_user:   prometheus
 prometheus_group:  prometheus
 
-prometheus_version:                 2.5.0
+prometheus_version:                 2.28.1
 prometheus_node_exporter_version:   0.16.0
 prometheus_alertmanager_version:    0.15.3
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -14,8 +14,8 @@ prometheus_user:   prometheus
 prometheus_group:  prometheus
 
 prometheus_version:                 2.28.1
-prometheus_node_exporter_version:   0.16.0
-prometheus_alertmanager_version:    0.15.3
+prometheus_node_exporter_version:   1.2.0
+prometheus_alertmanager_version:    0.22.2
 
 gosu_version: "1.11"
 prometheus_go_version:   1.11

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -3,7 +3,7 @@
 
 galaxy_info:
     author: williamyeh
-    description: Install and configure Prometheus
+    description: Install and configure Prometheus, Node Exporter and Alertmanager.
     license: MIT
 
     min_ansible_version: 2.2
@@ -14,10 +14,12 @@ galaxy_info:
               - trusty
               - xenial
               - bionic 
+              - focal
         - name: Debian
           versions:
               - jessie
               - wheezy
+              - buster
         - name: EL
           versions:
               - 7

--- a/tasks/install-compile-tools.yml
+++ b/tasks/install-compile-tools.yml
@@ -27,7 +27,7 @@
   set_fact:
     prometheus_golang_tarball_url: "https://storage.googleapis.com/golang/go{{ prometheus_go_version }}.linux-amd64.tar.gz"
     #prometheus_golang_tarball_url: "http://golang.org/dl/go{{ prometheus_go_version }}.linux-amd64.tar.gz"
-  when: ansible_userspace_bits == "64"
+  when: prometheus_platform_suffix == "linux-amd64"
 
 - name: set internal variables for convenience
   set_fact:

--- a/tasks/install-prometheus.yml
+++ b/tasks/install-prometheus.yml
@@ -96,7 +96,7 @@
   when: prometheus_use_systemd|bool
 
 - name: set INIT status
-  service: name=prometheus enabled=yes
+  service: name=prometheus enabled=yes daemon-reload=yes
   when: prometheus_use_service|bool
 
 

--- a/tasks/install-prometheus.yml
+++ b/tasks/install-prometheus.yml
@@ -95,10 +95,13 @@
   template: src="../templates/prometheus.service.j2"  dest="/etc/systemd/system/prometheus.service"
   when: prometheus_use_systemd|bool
 
-- name: set INIT status
-  service: name=prometheus enabled=yes daemon-reload=yes
-  when: prometheus_use_service|bool
+- name: Reload systemd unit files
+  command: systemctl daemon-reload
+  when: prometheus_use_systemd|bool
 
+- name: set INIT status
+  service: name=prometheus enabled=yes
+  when: prometheus_use_service|bool
 
 - name: copy rule files from playbook's, if any
   copy:

--- a/tasks/set-role-variables.yml
+++ b/tasks/set-role-variables.yml
@@ -9,15 +9,34 @@
   when: prometheus_use_service is not defined
 
 
+# Architecture: x64_64, CPU bit: 64
 - name: set internal variable platform-suffix for convenience
   set_fact:
     prometheus_platform_suffix: "linux-amd64"
-  when: ansible_userspace_bits == "64"
+  when: ansible_architecture == "x86_64"
+
+# Architecture: arm64, CPU bit: 64
+- name: set internal variable platform-suffix for convenience
+  set_fact:
+    prometheus_platform_suffix: "linux-arm64"
+  when: ansible_architecture == "aarch64"
+
+# Architecture: armv7, CPU bit: 32
+- name: set internal variable platform-suffix for convenience
+  set_fact:
+    prometheus_platform_suffix: "linux-386"
+  when: ansible_architecture == "armv7l"
+
+# Architecture: 386, CPU bit: 32
+- name: set internal variable platform-suffix for convenience
+  set_fact:
+    prometheus_platform_suffix: "linux-386"
+  when: ansible_architecture == "i386"
 
 - name: set internal variable platform-suffix for convenience
   set_fact:
     prometheus_platform_suffix: "linux-386"
-  when: ansible_userspace_bits == "32"
+  when: ansible_architecture == "i686"
 
 
 - block:

--- a/test/Dockerfile-debian10
+++ b/test/Dockerfile-debian10
@@ -1,0 +1,65 @@
+#
+# Version  1.0
+#
+
+
+# pull base image
+FROM debian:buster
+
+
+#
+# build phase
+#
+
+RUN echo "===> Adding Ansible's prerequisites..."         && \
+    apt-get update -y  &&  apt-get install --fix-missing  && \
+    echo "===> Installing Ansible..."  && \
+    apt-get install -y ansible git sudo curl build-essential \
+    python python-yaml gcc python-pip python-dev libffi-dev libssl-dev && \
+    echo "===> Adding hosts for convenience..."  && \
+    mkdir -p /etc/ansible                        && \
+    echo 'localhost' > /etc/ansible/hosts
+
+COPY ansible-playbook-wrapper /usr/local/bin/
+
+RUN  DEBIAN_FRONTEND=noninteractive  apt-get update   && \
+              echo "===> Updating TLS certificates..."         && \
+              apt-get install -y openssl ca-certificates
+
+WORKDIR  /tmp
+COPY  .  /tmp
+RUN  \
+              echo "===> Diagnosis: host information..."  && \
+              ansible -c local -m setup all
+
+ENV PLAYBOOK test.yml
+RUN ansible-playbook-wrapper -e 'prometheus_use_systemd=false'
+
+
+ENV PATH        /opt/ansible/bin:$PATH
+ENV PYTHONPATH  /opt/ansible/lib:$PYTHONPATH
+ENV MANPATH     /opt/ansible/docs/man:$MANPATH
+
+
+#
+# test phase
+#
+
+RUN echo "==> Removing PID files..."  && \
+    rm -f /var/run/prometheus/*
+
+RUN echo "===> Installing curl for testing purpose..."  && \
+    DEBIAN_FRONTEND=noninteractive  \
+    apt-get install -y -f curl
+
+
+VOLUME ["/data"]
+ENV    RESULT     /data/result-debian10
+
+CMD  \
+     service node_exporter start  &&  sleep 10  &&  \
+     service alertmanager start   &&  sleep 10  &&  \
+     service prometheus start     &&  sleep 60  &&  \
+     curl --retry 5 --retry-max-time 120  http://localhost:9100/metrics  > $RESULT   && \
+     curl --retry 5 --retry-max-time 120  http://localhost:9093/metrics  >> $RESULT  && \
+     curl --retry 5 --retry-max-time 120  http://localhost:9090/metrics  >> $RESULT

--- a/test/Dockerfile-ubuntu20.04
+++ b/test/Dockerfile-ubuntu20.04
@@ -1,0 +1,60 @@
+#
+# Version  1.0
+#
+
+
+# pull base image
+FROM ubuntu:20.04
+
+RUN apt-get update  && \
+    echo "===> Installing Ansible..."  && \
+    apt-get install -y ansible  && \
+    echo "===> Adding hosts for convenience..."  && \
+    echo 'localhost' > /etc/ansible/hosts
+
+
+COPY ansible-playbook-wrapper /usr/local/bin/
+
+RUN  DEBIAN_FRONTEND=noninteractive  apt-get update   && \
+              echo "===> Updating TLS certificates..."         && \
+              apt-get install -y openssl ca-certificates
+
+WORKDIR  /tmp
+COPY  .  /tmp
+RUN  \
+              echo "===> Diagnosis: host information..."  && \
+              ansible -c local -m setup all
+
+#
+# build phase
+#
+
+ENV PLAYBOOK test.yml
+RUN echo "===> Installing git for ansible galaxy..."  && \
+    DEBIAN_FRONTEND=noninteractive  \
+    apt-get install -y -f git
+RUN ansible-playbook-wrapper -e 'prometheus_use_systemd=false'
+
+
+#
+# test phase
+#
+
+RUN echo "==> Removing PID files..."  && \
+    rm -f /var/run/prometheus/*
+
+RUN echo "===> Installing curl for testing purpose..."  && \
+    DEBIAN_FRONTEND=noninteractive  \
+    apt-get install -y -f curl
+
+
+VOLUME ["/data"]
+ENV    RESULT     /data/result-ubuntu20.04
+
+CMD  \
+     service node_exporter start  &&  sleep 10  &&  \
+     service alertmanager start   &&  sleep 10  &&  \
+     service prometheus start     &&  sleep 60  &&  \
+     curl --retry 5 --retry-max-time 120  http://localhost:9100/metrics  > $RESULT   && \
+     curl --retry 5 --retry-max-time 120  http://localhost:9093/metrics  >> $RESULT  && \
+     curl --retry 5 --retry-max-time 120  http://localhost:9090/metrics  >> $RESULT


### PR DESCRIPTION
- Added support for arm64, armv7, i386 and i686 by using the ansible_architecture fact to set the platform sufix as suggested in issue #50. Tested these changes on a raspberry pi 3B and orange pi zero;
- Fixed an issue where the systemd unit was not being reloaded and caused the service to fail
- Support for Ubuntu 20.04 and Debian 10, added CI tests